### PR TITLE
Fix repository URL

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://www.haskell.org/ghcup
 site_description: GHCup is the main installer for the general purpose language Haskell.
 site_author: GHCup Team
 
-repo_url: https://github.com/haskell/ghcup-hs
+repo_url: https://github.com/haskell/ghcup-www
 
 theme:
     name: mkdocs


### PR DESCRIPTION
I'm not experienced with MkDocs but my conjecture is that this URL has only one effect -- the content of "Edit on GiHub" link. So, changing it to `ghcup-www`' repo should fix https://github.com/haskell/ghcup-hs/issues/1234