### PR TITLE
Update install.md for Debian 13

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -46,9 +46,13 @@ The following distro packages are required: `build-essential curl libffi-dev lib
 
 The following distro packages are required: `build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5`
 
-#### Version >= 12
+#### Version = 12
 
 The following distro packages are required: `build-essential curl libffi-dev libffi8 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5`
+
+#### Version >= 13
+
+The following distro packages are required: `build-essential curl libffi-dev libffi8 libgmp-dev libgmp10 libncurses-dev libncurses6 libtinfo6`
 
 ### Linux Ubuntu
 


### PR DESCRIPTION
On Debian 13 (codename Trixie), only libncurses6 is available
https://packages.debian.org/search?keywords=libncurses&searchon=names&suite=trixie&section=all

and libtinfo6
https://packages.debian.org/search?keywords=libtinfo&searchon=names&suite=trixie&section=all

Even though Debian 13 is not yet released, it has already entered its "freeze" phase (from March 15 2025).
https://release.debian.org/trixie/freeze_policy.html